### PR TITLE
fix(PaymentMethod): Remove useless error catcher block

### DIFF
--- a/app/code/community/UOL/PagSeguro/Model/PaymentMethod.php
+++ b/app/code/community/UOL/PagSeguro/Model/PaymentMethod.php
@@ -189,12 +189,7 @@ class UOL_PagSeguro_Model_PaymentMethod extends MethodAbstract
         //Define Extra Amount Information
         $paymentRequest->setExtraAmount($this->extraAmount());
 
-        try {
-            $paymentUrl = $paymentRequest->register($this->getCredentialsInformation());
-        } catch (PagSeguroServiceException $ex) {
-            Mage::log($ex->getMessage());
-            $this->redirectUrl(Mage::getUrl() . 'checkout/onepage');
-        }
+        $paymentUrl = $paymentRequest->register($this->getCredentialsInformation());
 
         return $paymentUrl;
     }


### PR DESCRIPTION
Besides the method UOL_PagSeguro_Model_PaymentMethod#redirectUrl does not exist,
that try/catch block was useless since only a controller is suppose
to set a redirect location in the HTTP response
