### PR TITLE
Adição de método para pegar ambiente de execução e tradução.

### DIFF
--- a/app/code/community/UOL/PagSeguro/Model/PaymentMethod.php
+++ b/app/code/community/UOL/PagSeguro/Model/PaymentMethod.php
@@ -37,6 +37,14 @@ class UOL_PagSeguro_Model_PaymentMethod extends Mage_Payment_Model_Method_Abstra
         $this->helper = new UOL_PagSeguro_Helper_Data();
     }
 
+
+    /**
+     * @return string
+     */
+    public function getEnvironment(){
+        return $this->library->getEnvironment();
+    }
+
     /**
      * @param Mage_Sales_Model_Order $order
      */

--- a/app/code/community/UOL/PagSeguro/Model/PaymentMethod.php
+++ b/app/code/community/UOL/PagSeguro/Model/PaymentMethod.php
@@ -51,7 +51,7 @@ class UOL_PagSeguro_Model_PaymentMethod extends Mage_Payment_Model_Method_Abstra
     public function addPagseguroOrders(Mage_Sales_Model_Order $order)
     {
         $orderId = $order->getEntityId();
-        $enviroment = $this->library->getEnvironment();
+        $enviroment = Mage::helper('pagseguro')->__($this->library->getEnvironment());
         $table = Mage::getConfig()->getTablePrefix().'pagseguro_orders';
         $read = Mage::getSingleton('core/resource')->getConnection('core_read');
         $value = $read->query("SELECT `order_id` FROM `$table` WHERE `order_id` = $orderId");

--- a/app/code/community/UOL/PagSeguro/etc/config.xml
+++ b/app/code/community/UOL/PagSeguro/etc/config.xml
@@ -185,6 +185,15 @@ limitations under the License.
         </events>
     </adminhtml>
     <frontend>
+        <translate>
+            <modules>
+                <pagseguro>
+                    <files>
+                        <default>UOL_PagSeguro.csv</default>
+                    </files>
+                </pagseguro>
+            </modules>
+        </translate>
         <routers>
             <pagseguro>
                 <use>standard</use>

--- a/app/locale/pt_BR/UOL_PagSeguro.csv
+++ b/app/locale/pt_BR/UOL_PagSeguro.csv
@@ -46,3 +46,5 @@
 "Moeda REAL não instalada.","Moeda REAL não instalada."
 "Moeda REAL instalada.","Moeda REAL instalada."
 "Sandbox ","Sandbox"
+"sandbox", "Sandbox - Teste"
+"production","Produção"


### PR DESCRIPTION
No controller
> app/code/community/UOL/PagSeguro/controllers/PaymentController.php 

"$this->payment->getEnvironment()" retorna nulo, devido o modelo 

> app/code/community/UOL/PagSeguro/Model/PaymentMethod.php

não ter o método implementado. O que leva sempre ao ambiente de Sandbox.
PaymentController.php linhas 148 e 191.

Essa PR contempla a adição do método no modelo.